### PR TITLE
properly supporting input nodes instead of just "folders"

### DIFF
--- a/lib/readMarkdownFolder.js
+++ b/lib/readMarkdownFolder.js
@@ -23,7 +23,7 @@ module.exports = function readMarkdownFolder(src, options) {
   return mdFiles
     .map(path => ({
       path,
-      content: readFileSync(join(options.folder, path)),
+      content: readFileSync(join(src, path)),
     }))
     .map((file) => {
       const front = yamlFront.loadFront(file.content);


### PR DESCRIPTION
This will allow anyone using broccoli-static-site-json to pass a Broccoli node instead of a folder name and for things to work exactly as before 👍 