### PR TITLE
Pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ new StaticSiteJson(`content`, {
 * `collate`: Boolean - Default: false
 
 ### CollationFileName
+
 If you have turned on collation by default BroccoliStaticSiteJson will  output
 the collated documents with the file name `all.json`. If you want to be able to
 edit this default output file you can set the `collationFileName`.
@@ -151,6 +152,89 @@ new StaticSiteJson(`content`, {
 ```
 
 * `collationFileName`: String - Default: `all.json`
+
+### paginate
+
+In most cases when you're using BroccoliStaticSiteJson you probably will not be
+dealing with collections that are too large. But in some cases, for example a
+blog, you want to be able to deal with collections of an arbitrary length and it
+would be useful to paginate your collated collections. To enable pagination you
+set `paginate` to be true in your options:
+
+```javascript
+new StaticSiteJson(`content`, {
+  collate: true,
+  paginate: true,
+})
+```
+
+**Note:** `paginate` will do nothing if you haven't set `collate` to true.
+
+This will produce a series of files in your output tree:
+
+```
+content/all.json
+content/all-0.json
+content/all-1.json
+content/all-2.json
+content/all-3.json
+...
+```
+
+Each of these files makes use of the [JSON:API spec's pagination
+meta](https://jsonapi.org/format/#fetching-pagination) and will have links
+entries for `first`, `last`, `next`, and `prev` as appropriate.
+
+**Note:** the contents of `content/all.json` and `content/all-0.json` are
+**exactly** the same. This is provided for simplicity and backwards
+compatibility when querying paginated collections.
+
+### pageSize
+
+By default, if you have turned on pagination, BroccoliStaticSiteJson will use a
+page size of 10 entries per file. If you want to change the page size then you
+can set the `pageSize` in the options:
+
+```javascript
+new StaticSiteJson(`content`, {
+  collate: true,
+  paginate: true,
+  pageSize: 20,
+})
+```
+
+Note: `pageSize` will do nothing if `paginate` is missing or set to false.
+
+### paginateSortFunction
+
+When paginating the order of the items in each page becomes very important, and
+will be highly dependent on your specific use case. For example, if you are
+using BroccoliStaticSiteJson for a blogging platform you will most likely want
+to order the posts by date and from latest to oldest.
+
+For this reason you can define a `paginateSortFunction()` that will be passed as
+a compareFunction into
+[Array.sort()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort).
+The full list of items will be sorted before they are chunked into pages. Here
+is a simplified example taken from what is used in
+[empress-blog](https://github.com/empress/empress-blog) to sort posts by date:
+
+```javascript
+const contentTree = new StaticSiteJson('content', {
+  attributes: ['date'], // this is simplified for the example
+  collate: true,
+  paginate: true,
+  paginateSortFunction(a, b) {
+    return b.date - a.date;
+  }
+});
+```
+
+**Note:** you can only sort based on attributes that have been defined in your
+`attributes` parameter. `id` is always available and is the name of the file
+by default.
+
+Note: `paginateSortFunction()` does nothing if `paginate` is not true;
 
 ### Relationships
 

--- a/README.md
+++ b/README.md
@@ -123,22 +123,34 @@ const jsonTree = new StaticSiteJson('really-strange_placeToPut_some_FILES', {
 
 **Note:** just like the folder example the type will be automatically pluralised.
 
-### Collections
-
-Collections are a convenient way of placing multiple markdown files (found under the same folder) in
-a single JSON:API document. This can be used when wanting to retrieve multiple documents at any one
-time (`findAll`).
+### Collate
+If you want to have the ability to query all of your content at once you can do
+that by **collating** content together in a collection. This will place all of
+your markdown files into a single JSON:API document and can be used for
+`findAll` queries. To turn on collation you just need to set the `collate`
+attribute to `true`
 
 ```javascript
 new StaticSiteJson(`content`, {
-  collections: [{
-    output: `allContent.json`,
-  }]
+  collate: true,
 })
 ```
 
-* `options`
-  * `output`: The output file name of the collection JSON:API document.
+* `collate`: Boolean - Default: false
+
+### CollationFileName
+If you have turned on collation by default BroccoliStaticSiteJson will  output
+the collated documents with the file name `all.json`. If you want to be able to
+edit this default output file you can set the `collationFileName`.
+
+```javascript
+new StaticSiteJson(`content`, {
+  collate: true,
+  collationFileName: 'articles.json'
+})
+```
+
+* `collationFileName`: String - Default: `all.json`
 
 ### Relationships
 

--- a/index.js
+++ b/index.js
@@ -147,8 +147,22 @@ class BroccoliStaticSiteJson extends Plugin {
 
             if (fileNameMatch) {
               fileName = `${fileNameMatch[1]}-${index}.json`;
+
+              serializedPageData.links = {
+                first: `/${this.options.contentFolder}/${fileNameMatch[1]}-0.json`,
+                last: `/${this.options.contentFolder}/${fileNameMatch[1]}-${contentPages.length - 1}.json`,
+                prev: index === 0 ? null : `/${this.options.contentFolder}/${fileNameMatch[1]}-${index - 1}.json`,
+                next: index === contentPages.length - 1 ? null : `/${this.options.contentFolder}/${fileNameMatch[1]}-${index + 1}.json`,
+              };
             } else {
               fileName = `${this.options.collationFileName}-${index}`;
+
+              serializedPageData.links = {
+                first: `/${this.options.contentFolder}/${fileNameMatch[1]}-0`,
+                last: `/${this.options.contentFolder}/${fileNameMatch[1]}-${contentPages.length - 1}`,
+                prev: index === 0 ? null : `/${this.options.contentFolder}/${fileNameMatch[1]}-${index - 1}`,
+                next: index === contentPages.length - 1 ? null : `/${this.options.contentFolder}/${fileNameMatch[1]}-${index + 1}`,
+              };
             }
 
             writeFileSync(

--- a/index.js
+++ b/index.js
@@ -137,7 +137,15 @@ class BroccoliStaticSiteJson extends Plugin {
         const collectionFileData = readMarkdownFolder(folder, this.options);
 
         if (this.options.paginate) {
-          const contentPages = _.chunk(collectionFileData, this.options.pageSize);
+          const contentPages = _.chain(collectionFileData)
+            .tap((items) => {
+              if (this.options.paginateSortFunction) {
+                return items.sort(this.options.paginateSortFunction);
+              }
+              return items;
+            })
+            .chunk(this.options.pageSize)
+            .value();
 
           contentPages.forEach((pageData, index) => {
             const serializedPageData = this.contentSerializer.serialize(pageData);

--- a/package-lock.json
+++ b/package-lock.json
@@ -128,6 +128,42 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
+      "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.1.tgz",
+      "integrity": "sha512-kMqzWDvtplLhIfqlsDSM2i7T37iHPyEa3Y2Mon/DNE84fnOHheRW0jpuJCxiGUcS5DLs+yGtJPyJpN9rdqMjlA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.2.0.tgz",
+      "integrity": "sha512-j5F1rScewLtx6pbTK0UAjA3jJj4RYiSKOix53YWv+Jzy/AZ69qHxUpU8fwVLjyKbEEud9QrLpv6Ggs7WqTimYw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.11"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@types/node": {
       "version": "10.12.18",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.18.tgz",
@@ -223,6 +259,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/array-equal/-/array-equal-1.0.0.tgz",
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-unique": {
@@ -2258,6 +2300,12 @@
         "graceful-fs": "^4.1.6"
       }
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "kind-of": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
@@ -2323,6 +2371,12 @@
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
       "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
+    "lolex": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.1.0.tgz",
+      "integrity": "sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==",
+      "dev": true
     },
     "lru-cache": {
       "version": "4.1.1",
@@ -2550,6 +2604,27 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.10.tgz",
+      "integrity": "sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "lolex": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+          "dev": true
+        }
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -3992,6 +4067,23 @@
       "integrity": "sha1-BrJhE/Vr6rBCVFojv6iAA8ysJg8=",
       "dev": true
     },
+    "path-to-regexp": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+      "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+      "dev": true,
+      "requires": {
+        "isarray": "0.0.1"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        }
+      }
+    },
     "path-type": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
@@ -4501,6 +4593,21 @@
             "ms": "2.0.0"
           }
         }
+      }
+    },
+    "sinon": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.2.5.tgz",
+      "integrity": "sha512-1c2KK6g5NQr9XNYCEcUbeFtBpKZD1FXEw0VX7gNhWUBtkchguT2lNdS7XmS7y64OpQWfSNeeV/f8py3NNcQ63Q==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.3.0",
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/samsam": "^3.2.0",
+        "diff": "^3.5.0",
+        "lolex": "^3.1.0",
+        "nise": "^1.4.10",
+        "supports-color": "^5.5.0"
       }
     },
     "slice-ansi": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.14.0",
     "mocha": "^5.2.0",
-    "nyc": "^13.1.0"
+    "nyc": "^13.1.0",
+    "sinon": "^7.2.5"
   }
 }

--- a/test/collections.js
+++ b/test/collections.js
@@ -66,7 +66,7 @@ title: more words
 ---
 # When one word is not enough`,
     }, {
-      collate: true
+      collate: true,
     });
 
     expect(files['index.json']).to.have.property('id', 'index');

--- a/test/deprecated/collections.js
+++ b/test/deprecated/collections.js
@@ -1,14 +1,11 @@
 const Funnel = require('broccoli-funnel');
-const sinon = require('sinon');
-
 const { createBuilder, createTempDir } = require('broccoli-test-helper');
 const { expect } = require('chai');
 
-const StaticSiteJson = require('../index');
+const StaticSiteJson = require('../../index');
 
 let output;
 let input;
-let warnSpy;
 
 async function buildFiles(files, options) {
   input.write({
@@ -31,15 +28,12 @@ async function buildFiles(files, options) {
   return outputFiles;
 }
 
-describe('collections', () => {
+describe('deprecated collections', () => {
   beforeEach(async () => {
     input = await createTempDir();
-    warnSpy = sinon.spy(console, 'warn');
   });
 
   afterEach(async () => {
-    // eslint-disable-next-line no-console
-    console.warn.restore();
     try {
       await input.dispose();
     } finally {
@@ -66,7 +60,9 @@ title: more words
 ---
 # When one word is not enough`,
     }, {
-      collate: true
+      collections: [{
+        output: 'all.json',
+      }],
     });
 
     expect(files['index.json']).to.have.property('id', 'index');
@@ -97,7 +93,9 @@ id: 3
 ---
 # When one word is not enough`,
     }, {
-      collate: true,
+      collections: [{
+        output: 'all.json',
+      }],
     });
 
     expect(files).to.have.property('1.json');
@@ -112,59 +110,12 @@ id: 3
     expect(files['all.json'].find(obj => obj.id === '3')).to.be.ok;
   });
 
-  it('tell you that that the collections attribute is deprecated', async () => {
-    const subject = new StaticSiteJson(input.path(), {
-      type: 'page',
-      collections: [{
-        output: 'all.json',
-      }],
-    });
-
-    output = createBuilder(subject);
-
-    input.write({
-      'index.md': `---
-title: a lovely title
----
-# Hello world`,
-    });
-
-    await output.build();
-
-    // assert that it was called with the correct value
-    expect(warnSpy.getCall(0).args[0]).to.eql('Using `collection` is deprecated. Please use collate and collationFileName instead.');
-  });
-
-  it('will warn you that that multiple collections will not be supported in the next version', async () => {
-    const subject = new StaticSiteJson(input.path(), {
-      type: 'page',
-      collections: [{
-        output: 'all.json',
-      }, {
-        output: 'another.json',
-      }],
-    });
-
-    output = createBuilder(subject);
-
-    input.write({
-      'index.md': `---
-title: a lovely title
----
-# Hello world`,
-    });
-
-    await output.build();
-
-    // assert that it was called with the correct value
-    expect(warnSpy.getCall(0).args[0]).to.eql('Using `collection` is deprecated. Please use collate and collationFileName instead.');
-    expect(warnSpy.getCall(1).args[0]).to.eql('Multiple collections will be removed in the next major release.');
-  });
-
   it('should allow you to define a collection and for the specified content folder to be exported as an single JSONAPI array response', async () => {
     const subject = new StaticSiteJson(input.path(), {
       type: 'page',
-      collate: true,
+      collections: [{
+        output: 'all.json',
+      }],
     });
 
     output = createBuilder(subject);
@@ -222,7 +173,9 @@ title: more words
 
     const subject = new StaticSiteJson(mdFiles, {
       type: 'page',
-      collate: true,
+      collections: [{
+        output: 'all.json',
+      }],
     });
 
     output = createBuilder(subject);
@@ -258,6 +211,4 @@ title: more words
       expect(allObject).to.deep.equal(individualObject.data);
     });
   });
-
-  it('should use the type definition of the StaticSiteJson in the collection');
 });

--- a/test/pagination.js
+++ b/test/pagination.js
@@ -135,4 +135,178 @@ title: duplicate
     expect(JSON.parse(folderOutput.content['all-0.json']).data).to.have.length(10);
     expect(JSON.parse(folderOutput.content['all-1.json']).data).to.have.length(2);
   });
+
+  it('should setup pagination links correctly', async () => {
+    const mdFiles = new Funnel(input.path(), { destDir: 'face' });
+
+    const subject = new StaticSiteJson(mdFiles, {
+      type: 'page',
+      collate: true,
+      paginate: true,
+      pageSize: 3,
+    });
+
+    output = createBuilder(subject);
+
+    input.write({
+      'index.md': `---
+title: a lovely title
+---
+# Hello world`,
+      'project.md': `---
+title: a less lovely title
+---
+# Goodbye world`,
+      'double-word.md': `---
+title: more words
+---
+# When one word is not enough`,
+      '1.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '2.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '3.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '4.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '5.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '6.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '7.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '8.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '9.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+    });
+
+    await output.build();
+
+    const folderOutput = output.read();
+    const pageOne = JSON.parse(folderOutput.content['all-0.json']);
+    const pageFour = JSON.parse(folderOutput.content['all-3.json']);
+
+    expect(pageOne.data).to.have.length(3);
+    expect(pageOne.links).to.deep.equal({
+      first: '/content/all-0.json',
+      last: '/content/all-3.json',
+      prev: null,
+      next: '/content/all-1.json',
+    });
+
+    expect(pageFour.data).to.have.length(3);
+    expect(pageFour.links).to.deep.equal({
+      first: '/content/all-0.json',
+      last: '/content/all-3.json',
+      prev: '/content/all-2.json',
+      next: null,
+    });
+  });
+
+  it('should prefix pagination links with the right contentFolder', async () => {
+    const mdFiles = new Funnel(input.path(), { destDir: 'face' });
+
+    const subject = new StaticSiteJson(mdFiles, {
+      type: 'page',
+      collate: true,
+      paginate: true,
+      pageSize: 3,
+      contentFolder: 'facey-face',
+    });
+
+    output = createBuilder(subject);
+
+    input.write({
+      'index.md': `---
+title: a lovely title
+---
+# Hello world`,
+      'project.md': `---
+title: a less lovely title
+---
+# Goodbye world`,
+      'double-word.md': `---
+title: more words
+---
+# When one word is not enough`,
+      '1.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '2.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '3.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '4.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '5.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '6.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '7.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '8.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '9.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+    });
+
+    await output.build();
+
+    const folderOutput = output.read();
+
+    const pageOne = JSON.parse(folderOutput['facey-face']['all-0.json']);
+    const pageFour = JSON.parse(folderOutput['facey-face']['all-3.json']);
+
+    expect(pageOne.data).to.have.length(3);
+    expect(pageOne.links).to.deep.equal({
+      first: '/facey-face/all-0.json',
+      last: '/facey-face/all-3.json',
+      prev: null,
+      next: '/facey-face/all-1.json',
+    });
+
+    expect(pageFour.data).to.have.length(3);
+    expect(pageFour.links).to.deep.equal({
+      first: '/facey-face/all-0.json',
+      last: '/facey-face/all-3.json',
+      prev: '/facey-face/all-2.json',
+      next: null,
+    });
+  });
 });

--- a/test/pagination.js
+++ b/test/pagination.js
@@ -1,0 +1,138 @@
+const Funnel = require('broccoli-funnel');
+const { createBuilder, createTempDir } = require('broccoli-test-helper');
+const { expect } = require('chai');
+
+const StaticSiteJson = require('../index');
+
+let output;
+let input;
+
+describe('pagination', () => {
+  beforeEach(async () => {
+    input = await createTempDir();
+  });
+
+  afterEach(async () => {
+    try {
+      await input.dispose();
+    } finally {
+      // do nothing
+    }
+
+    if (output) {
+      await output.dispose();
+    }
+  });
+
+  it('should allow you to specify page size with pagination', async () => {
+    const mdFiles = new Funnel(input.path(), { destDir: 'face' });
+
+    const subject = new StaticSiteJson(mdFiles, {
+      type: 'page',
+      collate: true,
+      paginate: true,
+      pageSize: 2,
+    });
+
+    output = createBuilder(subject);
+
+    input.write({
+      'index.md': `---
+title: a lovely title
+---
+# Hello world`,
+      'project.md': `---
+title: a less lovely title
+---
+# Goodbye world`,
+      'double-word.md': `---
+title: more words
+---
+# When one word is not enough`,
+    });
+
+    await output.build();
+
+    const folderOutput = output.read();
+
+    const allData = JSON.parse(folderOutput.content['all.json']).data;
+
+    expect(allData).to.have.length(2);
+    expect(folderOutput.content).to.have.property('all.json');
+    expect(folderOutput.content).to.have.property('all-0.json');
+    expect(folderOutput.content).to.have.property('all-1.json');
+
+    expect(folderOutput.content['all.json']).to.deep.equal(folderOutput.content['all-0.json']);
+    expect(JSON.parse(folderOutput.content['all.json']).data).to.have.length(2);
+  });
+
+  it('should automatically paginate 10 files when pagination is turned on', async () => {
+    const mdFiles = new Funnel(input.path(), { destDir: 'face' });
+
+    const subject = new StaticSiteJson(mdFiles, {
+      type: 'page',
+      collate: true,
+      paginate: true,
+    });
+
+    output = createBuilder(subject);
+
+    input.write({
+      'index.md': `---
+title: a lovely title
+---
+# Hello world`,
+      'project.md': `---
+title: a less lovely title
+---
+# Goodbye world`,
+      'double-word.md': `---
+title: more words
+---
+# When one word is not enough`,
+      '1.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '2.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '3.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '4.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '5.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '6.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '7.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '8.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+      '9.md': `---
+title: duplicate
+---
+# don't write duplicate content`,
+    });
+
+    await output.build();
+
+    const folderOutput = output.read();
+
+    expect(JSON.parse(folderOutput.content['all-0.json']).data).to.have.length(10);
+    expect(JSON.parse(folderOutput.content['all-1.json']).data).to.have.length(2);
+  });
+});


### PR DESCRIPTION
This PR deprecates collections (because multiple collections have never been used) and implements optional pagination that is turned off by default 🎉 

I have tested this in empress-blog and it is working nicely for very large blogs (i.e. [ember-blog](https://github.com/ember-learn/ember-blog/pull/7))

I have tried very hard to make sure that this PR can be merged and released as a **minor** version so if someone could review it with that in mind that would be great 👍 

## Todo: 

- [x] Implement page metadata for pagination
- [x] Test this setup in something like [empress-blog](https://github.com/empress/ember-ghost) and make sure that it meets the needs of the application
- [x] Document Pagination
