### PR TITLE
Fix showdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,3 +322,10 @@ const jsonTree = new StaticSiteJson('content', {
   - Contains a simple html representation of the Markdown file
 - `description` - _optional_
   - Contains the first 260 characters of the content of the file
+
+
+#### Markdown rendering configuration
+
+This plugin uses showdown to render markdown. right now we only support,
+global configuration of showdown, please see https://github.com/showdownjs/showdown#options
+for more details.

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ const jsonTree = new StaticSiteJson('content', {
   - Contains the first 260 characters of the content of the file
 
 
-#### Markdown rendering configuration
+### Markdown rendering configuration
 
 This plugin uses showdown to render markdown. right now we only support,
 global configuration of showdown, please see https://github.com/showdownjs/showdown#options

--- a/lib/readMarkdownFolder.js
+++ b/lib/readMarkdownFolder.js
@@ -12,10 +12,9 @@ const {
   readFileSync,
 } = require('fs');
 
-const converter = new showdown.Converter();
-
 module.exports = function readMarkdownFolder(src, options) {
   // build the tree of MD files
+  const converter = new showdown.Converter();
   const paths = walkSync(src);
 
   const mdFiles = paths.filter(path => extname(path) === '.md');

--- a/test/markdown.js
+++ b/test/markdown.js
@@ -1,0 +1,58 @@
+/**
+ * Ensures that you can configure showdown before requiring the plugin
+ */
+
+const showdown = require('showdown');
+const { createBuilder, createTempDir } = require('broccoli-test-helper');
+const { expect } = require('chai');
+
+const StaticSiteJson = require('../index');
+
+describe('basic tests', function () {
+  it('should throw an error if no folder is passed in');
+
+  it('should build JSON files using the folder name', function () {
+    return createTempDir()
+      .then((input) => {
+        showdown.setOption('tables', true);
+        const subject = new StaticSiteJson(input.path());
+        const output = createBuilder(subject);
+        const content = `
+  # Hello world
+  | Column |
+  |--------|
+  | row    |
+`;
+        input.write({
+          'index.md': content,
+        });
+
+        return output.build()
+          .then(() => {
+            const folderOutput = output.read();
+            const indexJSON = JSON.parse(folderOutput.content['index.json']);
+            const expectedContent = `<h1 id="helloworld">Hello world</h1>
+<table>
+<thead>
+<tr>
+<th>Column</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>row</td>
+</tr>
+</tbody>
+</table>`;
+            expect(indexJSON.data.attributes.html).to.eq(expectedContent);
+          })
+          .then(() => {
+            showdown.setOption('tables', false);
+            return Promise.all([
+              output.dispose(),
+              input.dispose(),
+            ]);
+          });
+      });
+  });
+});


### PR DESCRIPTION
Because the convertor is constructed when the file is required and not when the function is called, you need to ensure that you have configured showdown before requiring the plugin. By moving the Converter creation into the function it removes the race condition.

Also `package-lock.json` had a diff when installing packages i can remove the commit if you want.