### PR TITLE
[FEAT] Adds is_heading so items can specify that they are headings

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const TableOfContentsSerializer = new Serializer('page', {
     'title',
     'pages',
     'skip_toc',
+    'is_heading',
   ],
   keyForAttribute: 'cammelcase',
 });

--- a/test/core.js
+++ b/test/core.js
@@ -198,6 +198,10 @@ id: face
     input.write({
       'index.md': '# Hello world',
       'pages.yml': `
+- title: "Introduction
+  url: 'toc-heading-introduction'
+  is_heading: true
+
 - title: "Guides and Tutorials"
   url: 'index'
   skip_toc: true
@@ -225,6 +229,15 @@ id: face
     const folderOutput = output.read();
 
     expect(folderOutput.content).to.have.property('index.json');
+
+    expect(JSON.parse(folderOutput.content['pages.json']).data).to.deep.include({
+      type: 'pages',
+      id: 'toc-heading-introduction',
+      attributes: {
+        title: 'Introduction',
+        'is-heading': true,
+      },
+    });
 
     expect(JSON.parse(folderOutput.content['pages.json']).data).to.deep.include({
       type: 'pages',


### PR DESCRIPTION
Adds `is_heading` to pages so that they can specify that they are headings. Guidemaker can use this information to display the items as inert headings instead of links.