### PR TITLE
Adds support for custom relationship types

### DIFF
--- a/lib/markdown-to-jsonapi.js
+++ b/lib/markdown-to-jsonapi.js
@@ -29,9 +29,9 @@ class MarkDownToJsonApi extends PersistentFilter {
     this.converter = new showdown.Converter();
 
     const referenceAttributes = this.options.references.map((ref) => {
-      if (typeof ref === 'string') return ref;
-
       if (typeof ref === 'object') return ref.name;
+
+      return ref;
     });
 
     // build serialiser for jsonapi
@@ -53,6 +53,8 @@ class MarkDownToJsonApi extends PersistentFilter {
       if (customTypeRef) {
         return customTypeRef.type;
       }
+
+      return undefined;
     };
 
     this.serializer = new Serializer(this.options.type, serializerOptions);

--- a/lib/markdown-to-jsonapi.js
+++ b/lib/markdown-to-jsonapi.js
@@ -28,19 +28,32 @@ class MarkDownToJsonApi extends PersistentFilter {
 
     this.converter = new showdown.Converter();
 
+    const referenceAttributes = this.options.references.map((ref) => {
+      if (typeof ref === 'string') return ref;
+
+      if (typeof ref === 'object') return ref.name;
+    });
+
     // build serialiser for jsonapi
     const serializerOptions = {
       attributes: _.union(
         this.options.contentTypes,
         this.options.attributes,
-        this.options.references,
+        referenceAttributes,
       ),
       keyForAttribute: 'camelCase',
     };
 
-    this.options.references.forEach((reference) => {
+    referenceAttributes.forEach((reference) => {
       serializerOptions[reference] = { ref: true };
     });
+
+    serializerOptions.typeForAttribute = (attribute) => {
+      const customTypeRef = this.options.references.find((ref) => ref.name === attribute);
+      if (customTypeRef) {
+        return customTypeRef.type;
+      }
+    };
 
     this.serializer = new Serializer(this.options.type, serializerOptions);
   }

--- a/test/relationships.js
+++ b/test/relationships.js
@@ -1,3 +1,81 @@
-describe('references or relationships', () => {
-  it('should allow you to define references and for the value to become the id of the relationship in JSONAPI');
+const { createBuilder, createTempDir } = require('broccoli-test-helper');
+const { expect } = require('chai');
+
+const StaticSiteJson = require('../index');
+
+let output;
+let input;
+
+async function buildSingleFile(fileContents, options) {
+  input.write({
+    'index.md': fileContents,
+  });
+
+  const subject = new StaticSiteJson(input.path(), options);
+  output = createBuilder(subject);
+
+  await output.build();
+
+  const folderOutput = output.read();
+  const indexJSON = JSON.parse(folderOutput.content['index.json']);
+  return indexJSON.data;
+}
+
+describe.only('references or relationships', () => {
+  beforeEach(async () => {
+    input = await createTempDir();
+  });
+
+  afterEach(async () => {
+    try {
+      await input.dispose();
+    } finally {
+      // do nothing
+    }
+
+    if (output) {
+      await output.dispose();
+    }
+  });
+
+  it('should not include relationship for tag if the frontmatter is included but no options passed', async () => {
+    const result = await buildSingleFile(`---
+tag: face
+---
+# Hello world`);
+
+    expect(result).not.have.property('relationships');
+  });
+
+  it('should include title if the frontmatter is included and title is in attributes', async () => {
+    const result = await buildSingleFile(`---
+tag: face
+---
+# Hello world`, {
+      references: ['tag'],
+    });
+
+    expect(result).have.property('relationships');
+    expect(result.relationships.tag.data).have.property('id', 'face');
+    expect(result.relationships.tag.data).have.property('type', 'tags');
+  });
+
+  it('should allow you to customize the type of relationship', async () => {
+    const result = await buildSingleFile(`---
+tag: face
+profile: face.jpg
+foo: bar
+---
+# Hello world`, {
+      references: ['tag', { name: 'profile', type: 'images' }, { name: 'foo', type: 'notfoos' }],
+    });
+
+    expect(result).have.property('relationships');
+    expect(result.relationships.tag.data).have.property('id', 'face');
+    expect(result.relationships.tag.data).have.property('type', 'tags');
+    expect(result.relationships.profile.data).have.property('id', 'face.jpg');
+    expect(result.relationships.profile.data).have.property('type', 'images');
+    expect(result.relationships.foo.data).have.property('id', 'bar');
+    expect(result.relationships.foo.data).have.property('type', 'notfoos');
+  });
 });

--- a/test/relationships.js
+++ b/test/relationships.js
@@ -21,7 +21,7 @@ async function buildSingleFile(fileContents, options) {
   return indexJSON.data;
 }
 
-describe.only('references or relationships', () => {
+describe('references or relationships', () => {
   beforeEach(async () => {
     input = await createTempDir();
   });


### PR DESCRIPTION
- introduces support for custom relationship types
- optionally pass an object into references with a name and type property
- the type property will be used as the type for the relationship
- relationships that do no require custom types can still be passed into references as strings

Closes #16 
Relied upon by https://github.com/empress/empress-blog/pull/61