### PR TITLE
Support toc yaml

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,8 +27,10 @@ module.exports = function StaticSiteJson(folder, options = {}) {
   const tocFunnel = new BroccoliFunnel(folder, {
     include: [
       '**/pages.yml',
+      '**/pages.yaml',
       '**/pages.json',
       '**/toc.yml',
+      '**/toc.yaml',
       '**/toc.json',
     ],
   });

--- a/index.js
+++ b/index.js
@@ -25,7 +25,12 @@ module.exports = function StaticSiteJson(folder, options = {}) {
     include: ['**/*.md', '**/*.markdown'],
   });
   const tocFunnel = new BroccoliFunnel(folder, {
-    include: ['**/pages.yml', '**/pages.json'],
+    include: [
+      '**/pages.yml',
+      '**/pages.json',
+      '**/toc.yml',
+      '**/toc.json',
+    ],
   });
   const pagesTree = new TableOfContents(tocFunnel, options);
   const jsonApiTree = new MarkdownToJsonApi(cleanMarkdownFunnel, options);

--- a/lib/table-of-contents.js
+++ b/lib/table-of-contents.js
@@ -37,9 +37,9 @@ class TableOfContentsExtractor extends PersistentFilter {
   processString(content, relativePath) {
     let pages;
 
-    if (relativePath.endsWith('pages.yml')) {
+    if (relativePath.endsWith('.yml')) {
       pages = yaml.load(content);
-    } else if (relativePath.endsWith('pages.json')) {
+    } else if (relativePath.endsWith('.json')) {
       pages = JSON.parse(content);
     }
 

--- a/lib/table-of-contents.js
+++ b/lib/table-of-contents.js
@@ -29,7 +29,7 @@ function subpageUrls(parentUrl, currentPage, childPages) {
 class TableOfContentsExtractor extends PersistentFilter {
   constructor(folder, options) {
     super(folder, options);
-    this.extensions = ['yml', 'json'];
+    this.extensions = ['yaml', 'yml', 'json'];
     this.targetExtension = 'json';
   }
 
@@ -37,7 +37,7 @@ class TableOfContentsExtractor extends PersistentFilter {
   processString(content, relativePath) {
     let pages;
 
-    if (relativePath.endsWith('.yml')) {
+    if (relativePath.endsWith('.yml') || relativePath.endsWith('.yaml')) {
       pages = yaml.load(content);
     } else if (relativePath.endsWith('.json')) {
       pages = JSON.parse(content);

--- a/test/plugins/table-of-contents.js
+++ b/test/plugins/table-of-contents.js
@@ -5,59 +5,62 @@ const { expect } = require('chai');
 const TableOfContents = require('../../lib/table-of-contents');
 
 describe('table-of-contents', function () {
-  it('should build', async function () {
-    const input = await createTempDir();
-    try {
-      const subject = new TableOfContents(input.path());
-      const output = createBuilder(subject);
+  let input;
+  let output;
 
-      try {
-        // INITIAL
-        input.write({
-          'pages.yml': `- title: "Getting Started"
+  beforeEach(async function () {
+    input = await createTempDir();
+  });
+
+  afterEach(async function () {
+    await input.dispose();
+    await output.dispose();
+  });
+
+  it('should build pages.yml', async function () {
+    const subject = new TableOfContents(input.path());
+    output = createBuilder(subject);
+
+    // INITIAL
+    input.write({
+      'pages.yml': `- title: "Getting Started"
   url: 'getting-started'
   pages:
     - title: "How To Use The Guides"
       url: "intro"`,
-        });
+    });
 
-        await output.build();
+    await output.build();
 
-        expect(output.read()).to.deep.equal({
-          'pages.json': '{"data":[{"type":"pages","id":"getting-started","attributes":{"title":"Getting Started","pages":[{"title":"How To Use The Guides","url":"getting-started/intro"}]}}]}',
-        });
+    expect(output.read()).to.deep.equal({
+      'pages.json': '{"data":[{"type":"pages","id":"getting-started","attributes":{"title":"Getting Started","pages":[{"title":"How To Use The Guides","url":"getting-started/intro"}]}}]}',
+    });
 
-        expect(output.changes()).to.deep.equal({
-          'pages.json': 'create',
-        });
+    expect(output.changes()).to.deep.equal({
+      'pages.json': 'create',
+    });
 
-        // UPDATE
-        input.write({
-          'pages.yml': `- title: "Tutorial"
+    // UPDATE
+    input.write({
+      'pages.yml': `- title: "Tutorial"
   url: 'tutorial'
   pages:
     - title: "Creating Your App"
       url: "ember-cli"`, // change
-        });
-        await output.build();
+    });
+    await output.build();
 
-        expect(output.read()).to.deep.equal({
-          'pages.json': '{"data":[{"type":"pages","id":"tutorial","attributes":{"title":"Tutorial","pages":[{"title":"Creating Your App","url":"tutorial/ember-cli"}]}}]}',
-        });
+    expect(output.read()).to.deep.equal({
+      'pages.json': '{"data":[{"type":"pages","id":"tutorial","attributes":{"title":"Tutorial","pages":[{"title":"Creating Your App","url":"tutorial/ember-cli"}]}}]}',
+    });
 
-        expect(output.changes()).to.deep.equal({
-          'pages.json': 'change',
-        });
+    expect(output.changes()).to.deep.equal({
+      'pages.json': 'change',
+    });
 
-        // NOOP
-        await output.build();
+    // NOOP
+    await output.build();
 
-        expect(output.changes()).to.deep.equal({});
-      } finally {
-        await output.dispose();
-      }
-    } finally {
-      await input.dispose();
-    }
+    expect(output.changes()).to.deep.equal({});
   });
 });

--- a/test/plugins/table-of-contents.js
+++ b/test/plugins/table-of-contents.js
@@ -68,4 +68,31 @@ describe('table-of-contents', function () {
 
     expect(output.changes()).to.deep.equal({});
   });
+
+  it('should build toc.yml', async function () {
+    const subject = new StaticSiteJson(input.path());
+    output = createBuilder(subject);
+
+    // INITIAL
+    input.write({
+      'toc.yml': `- title: "Getting Started"
+  url: 'getting-started'
+  pages:
+    - title: "How To Use The Guides"
+      url: "intro"`,
+    });
+
+    await output.build();
+
+    expect(output.read()).to.deep.equal({
+      content: {
+        'toc.json': '{"data":[{"type":"pages","id":"getting-started","attributes":{"title":"Getting Started","pages":[{"title":"How To Use The Guides","url":"getting-started/intro"}]}}]}',
+      },
+    });
+
+    expect(output.changes()).to.deep.equal({
+      'content/': 'mkdir',
+      'content/toc.json': 'create',
+    });
+  });
 });

--- a/test/plugins/table-of-contents.js
+++ b/test/plugins/table-of-contents.js
@@ -2,7 +2,7 @@
 
 const { createBuilder, createTempDir } = require('broccoli-test-helper');
 const { expect } = require('chai');
-const TableOfContents = require('../../lib/table-of-contents');
+const StaticSiteJson = require('../../index');
 
 describe('table-of-contents', function () {
   let input;
@@ -18,7 +18,7 @@ describe('table-of-contents', function () {
   });
 
   it('should build pages.yml', async function () {
-    const subject = new TableOfContents(input.path());
+    const subject = new StaticSiteJson(input.path());
     output = createBuilder(subject);
 
     // INITIAL
@@ -33,11 +33,14 @@ describe('table-of-contents', function () {
     await output.build();
 
     expect(output.read()).to.deep.equal({
-      'pages.json': '{"data":[{"type":"pages","id":"getting-started","attributes":{"title":"Getting Started","pages":[{"title":"How To Use The Guides","url":"getting-started/intro"}]}}]}',
+      content: {
+        'pages.json': '{"data":[{"type":"pages","id":"getting-started","attributes":{"title":"Getting Started","pages":[{"title":"How To Use The Guides","url":"getting-started/intro"}]}}]}',
+      },
     });
 
     expect(output.changes()).to.deep.equal({
-      'pages.json': 'create',
+      'content/': 'mkdir',
+      'content/pages.json': 'create',
     });
 
     // UPDATE
@@ -51,11 +54,13 @@ describe('table-of-contents', function () {
     await output.build();
 
     expect(output.read()).to.deep.equal({
-      'pages.json': '{"data":[{"type":"pages","id":"tutorial","attributes":{"title":"Tutorial","pages":[{"title":"Creating Your App","url":"tutorial/ember-cli"}]}}]}',
+      content: {
+        'pages.json': '{"data":[{"type":"pages","id":"tutorial","attributes":{"title":"Tutorial","pages":[{"title":"Creating Your App","url":"tutorial/ember-cli"}]}}]}',
+      },
     });
 
     expect(output.changes()).to.deep.equal({
-      'pages.json': 'change',
+      'content/pages.json': 'change',
     });
 
     // NOOP

--- a/test/plugins/table-of-contents.js
+++ b/test/plugins/table-of-contents.js
@@ -95,4 +95,31 @@ describe('table-of-contents', function () {
       'content/toc.json': 'create',
     });
   });
+
+  it('should build toc.yaml', async function () {
+    const subject = new StaticSiteJson(input.path());
+    output = createBuilder(subject);
+
+    // INITIAL
+    input.write({
+      'toc.yaml': `- title: "Getting Started"
+  url: 'getting-started'
+  pages:
+    - title: "How To Use The Guides"
+      url: "intro"`,
+    });
+
+    await output.build();
+
+    expect(output.read()).to.deep.equal({
+      content: {
+        'toc.json': '{"data":[{"type":"pages","id":"getting-started","attributes":{"title":"Getting Started","pages":[{"title":"How To Use The Guides","url":"getting-started/intro"}]}}]}',
+      },
+    });
+
+    expect(output.changes()).to.deep.equal({
+      'content/': 'mkdir',
+      'content/toc.json': 'create',
+    });
+  });
 });


### PR DESCRIPTION
I'm in the middle of implementing https://github.com/empress/field-guide/issues/50 and it struck me that it's a bit odd that we call the yaml `pages.yml` and not `toc.yml` 🤔 so I thought we should at least support both 🤷 

This PR adds that support