### PR TITLE
allow you to pass showdownConfig for internal toc builder

### DIFF
--- a/lib/markdown-to-jsonapi.js
+++ b/lib/markdown-to-jsonapi.js
@@ -30,7 +30,7 @@ class MarkDownToJsonApi extends PersistentFilter {
       throw new Error(`Unknown content type: ${unsupportedContentTypes[0]}`);
     }
 
-    this.converter = new showdown.Converter();
+    this.converter = new showdown.Converter(this.options.showdownConfig);
 
     const referenceAttributes = this.options.references.map((ref) => {
       if (typeof ref === 'object') return ref.name;

--- a/test/attributes.js
+++ b/test/attributes.js
@@ -307,4 +307,22 @@ This is the first part
       { text: 'Hello world', depth: '1', id: 'helloworld' },
     ]);
   });
+
+  it('can provide config for showdown when building toc', async function () {
+    const result = await buildSingleFile(`# Hello world
+
+This is the only part
+
+`, {
+      contentTypes: ['toc'],
+      showdownConfig: {
+        ghCompatibleHeaderId: true,
+        prefixHeaderId: 'toc_',
+      },
+    });
+
+    expect(result.attributes.toc).to.deep.equal([
+      { text: 'Hello world', depth: '1', id: 'toc_hello-world' },
+    ]);
+  });
 });


### PR DESCRIPTION
This means that you can create a new broccoli plugin that you pass a `showdownConfig` and the showdown instance that builds the markdown for the headers in the toc will use that config 👍 